### PR TITLE
Not having grunt watch run unless 'grunt watch' is run

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,8 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-watch');
 
     // Default task.
-    grunt.registerTask( 'default', ['watch', 'concat', 'jshint', 'uglify', 'sass', 'cssmin'] );
+    grunt.registerTask( 'default', ['concat', 'jshint', 'uglify', 'sass', 'cssmin'] );
+    grunt.registerTask( 'dev', ['watch'] );
     grunt.registerTask( 'update', ['copy'] );
 
     grunt.util.linefeed = '\n';


### PR DESCRIPTION
It would be nice to not have grunt watch running as default, so this way running 'grunt' will just compile. Then 'grunt watch' will get it constantly watching as it currently does. 
